### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,7 +4,7 @@
 # Class
 #############################################
 
-CytronMD KEYWORD3
+CytronMD	KEYWORD3
 
 
 
@@ -12,7 +12,7 @@ CytronMD KEYWORD3
 # Methods and Functions 
 #############################################
 
-setSpeed KEYWORD2
+setSpeed	KEYWORD2
 
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords